### PR TITLE
Underline the accessibility link in the footer for consistency.

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -42,7 +42,7 @@ def home():
     return flask.redirect("/tariff")
 
 
-@app.route("/accessibility")
+@app.route("/accessibility", strict_slashes=False)
 def accessibility():
     return flask.render_template("accessibility.html")
 

--- a/src/static/css/application.css
+++ b/src/static/css/application.css
@@ -1579,3 +1579,7 @@ tr .highlight {
 p.govuk-body, .govuk-list li {
     font-size: 1.1875rem;
 }
+
+.govuk-footer__inline-list-item .govuk-footer__link {
+    text-decoration: underline;
+}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -67,7 +67,7 @@
                 <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
                     <ul class="govuk-footer__inline-list">
                         <li class="govuk-footer__inline-list-item">
-                          <a class="govuk-footer__link" href="/accessibility/">
+                          <a class="govuk-footer__link" href="/accessibility">
                             Accessibility
                           </a>
                         </li>


### PR DESCRIPTION
Also allow trailing slashes for the accessibility link to make it
more accessible.